### PR TITLE
implement new SMODS features

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -12,29 +12,7 @@ match_indent = true
 pattern = '''G.deck:shuffle('cashout'..G.GAME.round_resets.ante)'''
 position = "after"
 payload = '''
-for i=1, #G.jokers.cards do
-    eval_card(G.jokers.cards[i], {pl_cash_out = true})
-end
-'''
-
-#painterly joker context
-
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-match_indent = true
-pattern = '''self.config.card = card'''
-position = "before"
-payload = '''
-if self.config.card.suit then
-  if self.config.card.suit ~= card.suit then
-    if G.jokers and G.jokers.cards then
-      for i=1, #G.jokers.cards do
-        eval_card(G.jokers.cards[i], {pl_suit_changed = true})
-      end
-    end
-  end
-end
+SMODS.calculate_context({pl_cash_out = true})
 '''
 
 #lavender seal
@@ -64,28 +42,24 @@ match_indent = true
 pattern = '''add_tag(_tag.config.ref_table)'''
 position = "after"
 payload = '''
-if G.jokers and G.jokers.cards then
-    for i=1, #G.jokers.cards do
-        if G.jokers.cards[i].config.center.key == "j_pl_grape_soda" then
-        G.E_MANAGER:add_event(Event({
-        trigger = 'immediate',
-        func = function()
-          delay(0.3)
-          SMODS.calculate_context({skip_blind = true})
-          for i = 1, #G.GAME.tags do
-            G.GAME.tags[i]:apply_to_run({type = 'immediate'})
-          end
-          for i = 1, #G.GAME.tags do
-            if G.GAME.tags[i]:apply_to_run({type = 'new_blind_choice'}) then break end
-          end
-          return true
-        end
-      }))
-      _tag.children[2] = nil
-      _tag.children[1] = nil
-        return 
-        end
+if next(SMODS.find_card('j_pl_grape_soda')) then
+  G.E_MANAGER:add_event(Event({
+    trigger = 'immediate',
+    func = function()
+      delay(0.3)
+      SMODS.calculate_context({skip_blind = true})
+      for i = 1, #G.GAME.tags do
+        G.GAME.tags[i]:apply_to_run({type = 'immediate'})
+      end
+      for i = 1, #G.GAME.tags do
+        if G.GAME.tags[i]:apply_to_run({type = 'new_blind_choice'}) then break end
+      end
+      return true
     end
+  }))
+  _tag.children[2] = nil
+  _tag.children[1] = nil
+  return
 end
 '''
 
@@ -101,22 +75,6 @@ if G.GAME.pl_grape_used == G.GAME.blind_on_deck then
   _tag_container.children[1] = nil
 else
   G.GAME.pl_grape_used = nil
-end
-'''
-
-#lamp
-
-[[patches]]
-[patches.pattern]
-target = "card.lua"
-match_indent = true
-pattern = '''G.CONTROLLER.locks.selling_card = true'''
-position = "after"
-payload = '''
-for i=1, #G.jokers.cards do
-  if self.ability.set == 'Joker' then
-    eval_card(G.jokers.cards[i], {pl_selling_joker = true})
-  end
 end
 '''
 

--- a/src/additions/pl_jokers_w1.lua
+++ b/src/additions/pl_jokers_w1.lua
@@ -47,11 +47,9 @@ SMODS.Joker {
         }
       end
     end
-    if context.joker_main and context.cardarea == G.jokers then
-      return 
-      {
-        chip_mod = card.ability.extra.real_chips,
-        message = localize { type = 'variable', key = 'a_chips', vars = { card.ability.extra.real_chips } }
+    if context.joker_main then
+      return {
+        chips = card.ability.extra.real_chips
       }
     end
   end
@@ -70,17 +68,16 @@ SMODS.Joker {
   config = { extra = { Xmult = 1 } },
   attributes = {'xmult', 'scaling', 'on_sell'},
   loc_vars = function(self, info_queue, card)
-    return { vars = { card.ability.extra.Xmult + (G.GAME.pl_postcards_sold or 0) } }
+    return { vars = { card.ability.extra.Xmult * ((G.GAME.pl_postcards_sold or 0) + 1) } }
   end,
   calculate = function(self, card, context)
     if context.selling_self then
       G.GAME.pl_postcards_sold = (G.GAME.pl_postcards_sold or 0) + 1
     end
-    if context.joker_main and context.cardarea == G.jokers then
+    if context.joker_main then
       if G.GAME.pl_postcards_sold ~= nil then
         return {
-          Xmult_mod = card.ability.extra.Xmult + G.GAME.pl_postcards_sold,
-          message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.Xmult + G.GAME.pl_postcards_sold } }
+          xmult = card.ability.extra.Xmult * ((G.GAME.pl_postcards_sold or 0) + 1),
         }
       end
     end
@@ -107,7 +104,7 @@ SMODS.Joker {
     card.ability.extra.cw_size = pseudorandom_element(valid_cw_size, pseudoseed('crossword'..G.GAME.round_resets.ante)) 
 	end,
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.before and #context.full_hand == card.ability.extra.cw_size and not context.blueprint then
+    if context.before and #context.full_hand == card.ability.extra.cw_size and not context.blueprint then
       SMODS.scale_card(card, {
         ref_table = card.ability.extra,
         ref_value = 'mult',
@@ -116,15 +113,14 @@ SMODS.Joker {
       })
       return nil, true
     end
-    if context.joker_main and context.cardarea == G.jokers then
+    if context.joker_main then
       if card.ability.extra.mult > 0 then
         return {
-          mult_mod = card.ability.extra.mult,
-          message = localize { type = 'variable', key = 'a_mult', vars = { card.ability.extra.mult } }
+          mult = card.ability.extra.mult
         }
       end
     end
-    if context.end_of_round and not context.repetition and not context.individual then
+    if context.end_of_round and context.main_eval then
       local valid_cw_size = {3, 4, 5}
       table.remove(valid_cw_size, card.ability.extra.cw_size - 2)
       card.ability.extra.cw_size = pseudorandom_element(valid_cw_size, pseudoseed('crossword'..G.GAME.round_resets.ante)) 
@@ -168,7 +164,7 @@ SMODS.Joker {
         }
       end
     end
-    if context.end_of_round and not context.repetition and not context.individual then
+    if context.end_of_round and context.main_eval then
       local numbers = {2, 3, 4, 5, 6, 7, 8, 9, 10}
       local bingo1 = pseudorandom_element(numbers, pseudoseed('bingo'..G.GAME.round_resets.ante))
       table.remove(numbers, bingo1 - 1)
@@ -291,9 +287,7 @@ SMODS.Joker {
     if context.cardarea == G.play and context.repetition and not context.repetition_only then
       if next(context.poker_hands['Straight']) then
         return {
-          message = localize("k_again_ex"),
-          repetitions = card.ability.extra.repetitions,
-          card = card,
+          repetitions = card.ability.extra.repetitions
         }
       end
     end
@@ -317,9 +311,7 @@ SMODS.Joker {
       if context.other_card.ability.set ~= 'Enhanced' then
         return 
         {
-          message = localize("k_again_ex"),
-          repetitions = card.ability.extra.repetitions,
-          card = card, 
+          repetitions = card.ability.extra.repetitions
         }
       end
     end
@@ -342,7 +334,7 @@ SMODS.Joker {
     info_queue[#info_queue + 1] = G.P_CENTERS.m_stone
   end,
   calculate = function(self, card, context)
-    if context.after and context.cardarea == G.jokers then
+    if context.after then
       local stone = false
       for i = 1, #context.scoring_hand do
         if SMODS.has_enhancement(context.scoring_hand[i], 'm_stone') then
@@ -422,14 +414,10 @@ SMODS.Joker {
       end
     end
 
-    if context.joker_main and context.cardarea == G.jokers then
-      if card.ability.extra.chips > 0 then
-        return 
-        {
-          chip_mod = card.ability.extra.chips,
-          message = localize { type = 'variable', key = 'a_chips', vars = { card.ability.extra.chips } }
-        }
-      end
+    if context.joker_main then
+      return {
+        chips = card.ability.extra.chips
+      }
     end
   end
 }
@@ -447,7 +435,7 @@ SMODS.Joker {
   cost = 8,
   attributes = {'generation'},
   calculate = function(self, card, context)
-    if context.cardarea == G.jokers and context.before and #G.hand.cards > 0 then
+    if context.before and #G.hand.cards > 0 then
       local removed_card = pseudorandom_element(G.hand.cards, pseudoseed('mossy_joker'))
       local copied_card = pseudorandom_element(context.scoring_hand, pseudoseed('mossy_joker'))
       removed_card:flip()
@@ -499,8 +487,7 @@ SMODS.Joker {
         end
       }))
       return {
-        message = localize{type = 'variable',key = 'a_xmult', vars = { card.ability.extra.Xmult } },
-        Xmult_mod = card.ability.extra.Xmult,
+        xmult = card.ability.extra.Xmult,
         focus = context.other_joker
       }
     end
@@ -523,7 +510,7 @@ SMODS.Joker {
     return { vars = { localize(card.ability.extra.is_odd), localize(card.ability.extra.next_round), card.ability.extra.Xmult} }
   end,
   calculate = function(self, card, context)
-    if context.end_of_round and not context.repetition and not context.individual and not context.blueprint then
+    if context.end_of_round and context.main_eval and not context.blueprint then
       card.ability.extra.is_odd, card.ability.extra.next_round = card.ability.extra.next_round, card.ability.extra.is_odd
     end
 
@@ -570,7 +557,7 @@ SMODS.Joker {
     Food = true
   },
   calculate = function(self, card, context)
-    if context.end_of_round and G.GAME.blind.boss and not context.repetition and not context.individual and not context.blueprint then
+    if context.end_of_round and G.GAME.blind.boss and context.main_eval and not context.blueprint then
       card.ability.extra.reduce_ante = "pl_active"
       local eval = function(card) return not card.REMOVED end
       juice_card_until(card, eval, true)

--- a/src/additions/pl_jokers_w1.lua
+++ b/src/additions/pl_jokers_w1.lua
@@ -2,6 +2,7 @@ SMODS.Joker {
   key = 'plantain',
   config = { 
     extra = {chips = 80, chance = 4} },
+  attributes = {'chips', 'chance', 'food'},
   rarity = 1,
   atlas = 'pl_atlas_w1',
   blueprint_compat = true,
@@ -81,6 +82,7 @@ SMODS.Joker {
   cost = 2,
   discovered = true,
   config = { extra = { Xmult = 1 } },
+  attributes = {'xmult', 'scaling', 'on_sell'},
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.Xmult + (G.GAME.pl_postcards_sold or 0) } }
   end,
@@ -110,6 +112,7 @@ SMODS.Joker {
   perishable_compat = false,
   pos = { x = 2, y = 0 },
   config = { extra = { mult_mod = 1, cw_size = 1 , mult = 0} },
+  attributes = {'mult', 'scaling'},
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.mult_mod, card.ability.extra.cw_size, card.ability.extra.mult} }
   end,
@@ -149,6 +152,7 @@ SMODS.Joker {
   cost = 5,
   discovered = true,
   config = { extra = { mult = 5, chips = 25, bingo1 = 3, bingo2 = 7 } },
+  attributes = {'mult', 'chips', 'rank'},
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.bingo1, card.ability.extra.bingo2, card.ability.extra.chips, card.ability.extra.mult } }
   end,
@@ -190,6 +194,7 @@ SMODS.Joker {
 SMODS.Joker {
   key = 'apple_pie',
   config = { extra = { money = 6, money_loss = 1 } },
+  attributes = {'economy', 'scaling', 'food'},
   rarity = 1,
   atlas = 'pl_atlas_w1',
   blueprint_compat = false,
@@ -244,6 +249,7 @@ SMODS.Joker {
   rarity = 2,
   atlas = 'pl_atlas_w1',
   config = { extra = { should_destroy = true } },
+  attributes = {'skip', 'tag', 'food'},
   discovered = true,
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.should_destroy } }
@@ -289,6 +295,7 @@ SMODS.Joker {
 SMODS.Joker {
   key = 'matryoshka',
   config = { extra = { repetitions = 1 } },
+  attributes = {'retrigger', 'hand_type'},
   rarity = 2,
   atlas = 'pl_atlas_w1',
   blueprint_compat = true,
@@ -313,6 +320,7 @@ SMODS.Joker {
 SMODS.Joker {
   key = 'jim',
   config = { extra = { repetitions = 1 } },
+  attributes = {'retrigger', 'enhancements'},
   rarity = 2,
   atlas = 'pl_atlas_w1',
   blueprint_compat = true,
@@ -346,6 +354,7 @@ SMODS.Joker {
   pos = { x = 3, y = 1 },
   cost = 6,
   enhancement_gate = 'm_stone',
+  attributes = {'generation', 'tarot', 'enhancements'},
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = G.P_CENTERS.m_stone
   end,
@@ -381,6 +390,7 @@ SMODS.Joker {
 SMODS.Joker {
   key = 'el_dorado',
   config = { extra = { money_mod = 3 } },
+  attributes = {'economy', 'enhancements', 'full_deck'},
   rarity = 2,
   discovered = true,
   atlas = 'pl_atlas_w1',
@@ -410,6 +420,7 @@ SMODS.Joker {
   eternal_compat = true,
   perishable_compat = false,
   config = { extra = { chips_mod = 13, chips = 0 } },
+  attributes = {'chips', 'enhancements', 'scaling'}, -- i would also add 'chance' but lucky cat from vanilla doesn't so i won't for consistency
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = G.P_CENTERS.m_lucky
     return { vars = { card.ability.extra.chips_mod , card.ability.extra.chips } }
@@ -449,6 +460,7 @@ SMODS.Joker {
   perishable_compat = true,
   pos = { x = 1, y = 2 },
   cost = 8,
+  attributes = {'generation'},
   calculate = function(self, card, context)
     if context.cardarea == G.jokers and context.before and #G.hand.cards > 0 then
       local removed_card = pseudorandom_element(G.hand.cards, pseudoseed('mossy_joker'))
@@ -479,6 +491,7 @@ SMODS.Joker {
   cost = 8,
   discovered = true,
   config = { extra = { Xmult = 2 } },
+  attributes = {'xmult', 'joker'},
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.Xmult } }
   end,
@@ -520,6 +533,7 @@ SMODS.Joker {
   cost = 7,
   discovered = true,
   config = { extra = { is_odd = 'pl_even', next_round = 'pl_odd', Xmult = 1.5} },
+  attributes = {'xmult', 'rank'},
   loc_vars = function(self, info_queue, card)
     return { vars = { localize(card.ability.extra.is_odd), localize(card.ability.extra.next_round), card.ability.extra.Xmult} }
   end,
@@ -550,6 +564,8 @@ SMODS.Joker {
   end
 }
 
+SMODS.attribute {key = 'ante'}
+
 SMODS.Joker {
   key = 'raw_meat',
   rarity = 3,
@@ -558,6 +574,7 @@ SMODS.Joker {
   eternal_compat = false,
   perishable_compat = true,
   config = { extra = { minus_ante = -1, reduce_ante = "pl_inactive" } },
+  attributes = {'ante', 'boss_blind', 'on_sell'},
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.minus_ante, localize(card.ability.extra.reduce_ante) } }
   end,

--- a/src/additions/pl_jokers_w1.lua
+++ b/src/additions/pl_jokers_w1.lua
@@ -15,9 +15,10 @@ SMODS.Joker {
     Food = true
   },
   loc_vars = function(self, info_queue, card)
-    return { vars = { (card.ability.extra.real_chips or G.GAME.pl_plantain_chips or card.ability.extra.chips),
-      (G.GAME.probabilities.normal or 1),
-      (card.ability.extra.real_chance or G.GAME.pl_plantain_chance or card.ability.extra.chance),  } }
+    return { vars = {
+      (card.ability.extra.real_chips or G.GAME.pl_plantain_chips or card.ability.extra.chips),
+      SMODS.get_probability_vars(card, 1, card.ability.extra.real_chance or G.GAME.pl_plantain_chance or card.ability.extra.chance, 'plantain')
+    } }
   end,
   add_to_deck = function(self,card,context)
     if G.GAME.pl_plantain_chips == nil then
@@ -33,25 +34,10 @@ SMODS.Joker {
   end,
   calculate = function(self, card, context)
     if context.end_of_round and not context.blueprint and not context.repetition and not context.individual then
-      if pseudorandom('plantain') < G.GAME.probabilities.normal/card.ability.extra.real_chance then 
+      if SMODS.pseudorandom_probability(card, 'plantain', 1, card.ability.extra.real_chance) then 
         G.GAME.pl_plantain_chips = (G.GAME.pl_plantain_chips or card.ability.extra.chips) + card.ability.extra.chips
         G.GAME.pl_plantain_chance = (G.GAME.pl_plantain_chance or card.ability.extra.chance) + card.ability.extra.chance
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                card.T.r = -0.2
-                card:juice_up(0.3, 0.4)
-                card.states.drag.is = true
-                card.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            card:remove()
-                            card = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
+        SMODS.destroy_cards(card, nil, nil, true)
         return {
             message = localize('pl_plantain_cooked')
         }
@@ -122,8 +108,13 @@ SMODS.Joker {
 	end,
   calculate = function(self, card, context)
     if context.cardarea == G.jokers and context.before and #context.full_hand == card.ability.extra.cw_size and not context.blueprint then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_mod
-      return { message = localize('k_upgrade_ex'), focus = card, colour = G.C.MULT}
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_mod',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
     if context.joker_main and context.cardarea == G.jokers then
       if card.ability.extra.mult > 0 then
@@ -218,27 +209,21 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.pl_cash_out and not context.blueprint then
-      card.ability.extra.money = card.ability.extra.money - card.ability.extra.money_loss
-      if card.ability.extra.money == 0 then
-        G.E_MANAGER:add_event(Event({
-          func = function()
-              play_sound('tarot1')
-              card.T.r = -0.2
-              card:juice_up(0.3, 0.4)
-              card.states.drag.is = true
-              card.children.center.pinch.x = true
-              G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                  func = function()
-                          G.jokers:remove_card(self)
-                          card:remove()
-                          card = nil
-                      return true; end})) 
-              return true
-          end
-        })) 
+      if card.ability.extra.money - card.ability.extra.money_loss <= 0 then
+        SMODS.destroy_cards(card, nil, nil, true)
         card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize('pl_apple_pie_sold_out'), colour = G.C.MONEY})
       else
-        card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize('pl_apple_pie_slice'), colour = G.C.MONEY})
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'money',
+          scalar_value = 'money_loss',
+          operation = '-',
+          scaling_message = {
+            message = localize('pl_apple_pie_slice'),
+            colour = G.C.MONEY
+          }
+        })
+        return nil, true
      end
     end
   end
@@ -266,16 +251,14 @@ SMODS.Joker {
     if context.skip_blind and not context.blueprint then
       G.E_MANAGER:add_event(Event({
         func = function()
-          for i=1, #G.jokers.cards do
-            other_soda = G.jokers.cards[i]
-            if other_soda.ability.name == card.ability.name and other_soda ~= card and card.ability.extra.should_destroy then
+          for _,other_soda in ipairs(SMODS.find_card('j_pl_grape_soda')) do
+            if other_soda ~= card and card.ability.extra.should_destroy then
               other_soda.ability.extra.should_destroy = false
             end
           end
           if card.ability.extra.should_destroy then
             card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize('pl_grape_soda_gulp'), colour = G.C.RED})
-            card:start_dissolve({G.C.RED}, card)
-            play_sound('whoosh2')
+            SMODS.destroy_cards(card, nil, nil, nil, {G.C.RED})
             G.E_MANAGER:add_event(Event({delay = 0.2,
               func = function()
                 G.GAME.pl_grape_used = G.GAME.blind_on_deck
@@ -362,26 +345,23 @@ SMODS.Joker {
     if context.after and context.cardarea == G.jokers then
       local stone = false
       for i = 1, #context.scoring_hand do
-        if context.scoring_hand[i].ability.effect == "Stone Card" then stone = true
+        if SMODS.has_enhancement(context.scoring_hand[i], 'm_stone') then
+          stone = true
+          break
+        end
       end
-    end
       if stone and (#G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit) then
         G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
-        G.E_MANAGER:add_event(Event({
-          trigger = 'before',
-          delay = 0.0,
-          func = (function()
-                  local card = create_card('Tarot',G.consumeables, nil, nil, nil, nil, nil, 'sup')
-                  card:add_to_deck()
-                  G.consumeables:emplace(card)
-                  G.GAME.consumeable_buffer = 0
-              return true
-          end)}))
-      return {
+        G.E_MANAGER:add_event(Event({func = function()
+          SMODS.add_card{set = 'Tarot', area = G.consumeables, key_append = 'sup'}
+          G.GAME.consumeable_buffer = 0
+          return true
+        end}))
+        return {
           message = localize('k_plus_tarot'),
           colour = G.C.SECONDARY_SET.Tarot,
           card = card
-      }
+        }
       end
     end
   end
@@ -432,8 +412,13 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.cardarea == G.play and context.individual and not context.blueprint then
       if SMODS.has_enhancement(context.other_card, 'm_lucky') and not context.other_card.lucky_trigger then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chips_mod
-        return { message = localize('k_upgrade_ex'), focus = card}
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'chips_mod',
+          no_message = true
+        })
+        return { message = localize('k_upgrade_ex'), focus = card }
       end
     end
 
@@ -564,7 +549,7 @@ SMODS.Joker {
   end
 }
 
-SMODS.attribute {key = 'ante'}
+SMODS.Attribute {key = 'ante'}
 
 SMODS.Joker {
   key = 'raw_meat',

--- a/src/additions/pl_jokers_w2.lua
+++ b/src/additions/pl_jokers_w2.lua
@@ -30,22 +30,7 @@ SMODS.Joker {
       if not context.blueprint then
         card.ability.extra.upgrades_left = card.ability.extra.upgrades_left - 1
         if card.ability.extra.upgrades_left <= 0 then
-          G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                card.T.r = -0.2
-                card:juice_up(0.3, 0.4)
-                card.states.drag.is = true
-                card.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-              func = function()
-                G.jokers:remove_card(self)
-                card:remove()
-                card = nil
-              return true; end})) 
-            return true
-          end
-          })) 
+          SMODS.destroy_cards(card, nil, nil, true)
           return {
               message = localize('k_eaten_ex')
           }
@@ -64,7 +49,7 @@ SMODS.Joker {
   
   config = { extra = { chance = 2 } },
   loc_vars = function(self, info_queue, card)
-    return { vars = { (G.GAME.probabilities.normal or 1), card.ability.extra.chance} }
+    return { vars = { SMODS.get_probability_vars(card, 1, card.ability.extra.chance, 'popup') } }
   end,
   attributes = {'chance', 'reroll', 'generation', 'booster', 'shop'},
 
@@ -79,7 +64,7 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.reroll_shop then
       if #G.shop_booster.cards < G.GAME.starting_params.boosters_in_shop + (G.GAME.modifiers.extra_boosters or 0) then
-        if pseudorandom('popup') < G.GAME.probabilities.normal/card.ability.extra.chance then
+        if SMODS.pseudorandom_probability(card, 'popup', 1, card.ability.extra.chance) then
           G.E_MANAGER:add_event(Event {
             func = function()
               PL_UTIL.add_booster_pack()
@@ -125,14 +110,25 @@ SMODS.Joker {
   cost = 5,
 
   calculate = function (self, card, context)
-    if context.pl_selling_joker and not context.blueprint then
-      card.ability.extra.mult = card.ability.extra.mult + card.ability.extra.mult_gain
-      card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize{type='variable',key='a_mult',vars={card.ability.extra.mult_gain}}})
+    if context.selling_card and context.card.ability.set == 'Joker' and not context.blueprint then
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_gain',
+        message_key = 'a_mult'
+      })
+      return nil, true
     end
     
     if context.end_of_round and not context.blueprint and not context.repetition and not context.individual and card.ability.extra.mult > 0 then
-      card.ability.extra.mult = card.ability.extra.mult - card.ability.extra.mult_loss
-      card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize{type='variable',key='a_mult_minus',vars={card.ability.extra.mult_loss}}})
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'mult',
+        scalar_value = 'mult_loss',
+        operation = '-',
+        message_key = 'a_mult_minus'
+      })
+      return nil, true
     end
 
     if context.joker_main and context.cardarea == G.jokers then
@@ -179,12 +175,13 @@ SMODS.Joker {
         if matches > 1 then pair = true end
       end
       if not pair then
-        card.ability.extra.chips = card.ability.extra.chips + card.ability.extra.chips_mod
-        return {
-          message = localize('k_upgrade_ex'),
-          colour = G.C.Chips,
-          card = card
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'chips',
+          scalar_value = 'chips_mod',
+          message_colour = G.C.CHIPS
+        })
+        return nil, true
       end
     end
 
@@ -206,7 +203,7 @@ SMODS.Joker {
   
   config = { extra = { money = 1, money_mod = 1, chance = 15 } },
   loc_vars = function(self, info_queue, card)
-    return { vars = { card.ability.extra.money, card.ability.extra.money_mod, (G.GAME.probabilities.normal or 1), card.ability.extra.chance } }
+    return { vars = { card.ability.extra.money, card.ability.extra.money_mod, SMODS.get_probability_vars(card, 1, card.ability.extra.chance, 'balloon') } }
   end,
   attributes = {'economy', 'tarot', 'chance'},
 
@@ -225,31 +222,18 @@ SMODS.Joker {
 
   calculate = function(self, card, context)
     if context.using_consumeable and not context.blueprint and not context.repetition and not context.individual and (context.consumeable.ability.set == "Tarot") then
-      if pseudorandom('balloon') < G.GAME.probabilities.normal/card.ability.extra.chance then
-        G.E_MANAGER:add_event(Event({
-            func = function()
-                play_sound('tarot1')
-                card.T.r = -0.2
-                card:juice_up(0.3, 0.4)
-                card.states.drag.is = true
-                card.children.center.pinch.x = true
-                G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                    func = function()
-                            G.jokers:remove_card(self)
-                            card:remove()
-                            card = nil
-                        return true; end})) 
-                return true
-            end
-        })) 
+      if SMODS.pseudorandom_probability(card, 'balloon', 1, card.ability.extra.chance) then
+        SMODS.destroy_cards(card, nil, nil, true)
         return {
             message = localize('pl_hot_air_balloon_pop')
         }
       else
-        card.ability.extra.money = card.ability.extra.money + card.ability.extra.money_mod
-        return {
-            message = localize('k_upgrade_ex')
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'money',
+          scalar_value = 'money_mod'
+        })
+        return nil, true
       end
     end
   end
@@ -287,13 +271,11 @@ SMODS.Joker {
   calculate = function(self, card, context)
     if context.before and context.cardarea == G.jokers then
       if (context.scoring_name == 'Three of a Kind') and not (card.ability.extra.last_hand == 'none') then
-        -- card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize('k_upgrade_ex'), colour = G.C.PURPLE})
-        local text = card.ability.extra.last_hand
-        local old_text = context.scoring_name
-        card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize('k_level_up_ex')})
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(text, 'poker_hands'),chips = G.GAME.hands[text].chips, mult = G.GAME.hands[text].mult, level=G.GAME.hands[text].level})
-        level_up_hand(context.blueprint_card or card, text, nil, 1)
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(old_text, 'poker_hands'),chips = G.GAME.hands[old_text].chips, mult = G.GAME.hands[old_text].mult, level=G.GAME.hands[old_text].level})
+        return {
+          message = localize('k_level_up_ex'),
+          level_up = 1,
+          level_up_hand = card.ability.extra.last_hand
+        }
       end
     end
     if context.cardarea == G.jokers and context.joker_main then
@@ -309,7 +291,7 @@ SMODS.Joker {
   
   config = { extra = { chance = 2 } },
   loc_vars = function(self, info_queue, card)
-    return { vars = { (G.GAME.probabilities.normal or 1), card.ability.extra.chance } }
+    return { vars = { SMODS.get_probability_vars(card, 1, card.ability.extra.chance, 'batteries') } }
   end,
   attributes = {'retrigger', 'chance', 'rank', 'ace'},
 
@@ -325,7 +307,7 @@ SMODS.Joker {
     if context.cardarea == G.play and context.repetition then
       if context.other_card:get_id() == 14 then
         local retriggers = 1
-        if pseudorandom('batteries') < G.GAME.probabilities.normal/card.ability.extra.chance then 
+        if SMODS.pseudorandom_probability(card, 'batteries', 1, card.ability.extra.chance) then 
           retriggers = 2
         end
         return 
@@ -368,9 +350,14 @@ SMODS.Joker {
           }
       end
     end
-    if context.pl_suit_changed and not context.blueprint then
-      card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
-      card_eval_status_text(card, 'jokers', nil, nil, nil, {message = localize('k_upgrade_ex'), colour = G.C.MULT})
+    if context.change_suit and not context.blueprint then
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xmult',
+        scalar_value = 'xmult_mod',
+        message_colour = G.C.MULT
+      })
+      return nil, true
     end
   end
 }
@@ -398,11 +385,16 @@ SMODS.Joker {
   cost = 6,
 
   calculate = function(self, card, context)
-    if context.cardarea == G.play and context.other_card and context.other_card.ability.effect == 'Stone Card' and context.individual and not context.blueprint then
-      card.ability.extra.xmult = card.ability.extra.xmult + card.ability.extra.xmult_mod
-      return { message = localize('k_upgrade_ex'), focus = card, colour = G.C.MULT}
+    if context.cardarea == G.play and context.other_card and SMODS.has_enhancement(context.other_card, 'm_stone') and context.individual and not context.blueprint then
+      SMODS.scale_card(card, {
+        ref_table = card.ability.extra,
+        ref_value = 'xmult',
+        scalar_value = 'xmult_mod',
+        no_message = true
+      })
+      return { message = localize('k_upgrade_ex'), focus = card, colour = G.C.MULT }
     end
-    if context.destroying_card and context.destroying_card.ability.effect == 'Stone Card' and not context.blueprint then
+    if context.destroying_card and SMODS.has_enhancement(context.destroying_card, 'm_stone') and not context.blueprint then
       return true
     end
     if context.joker_main and context.cardarea == G.jokers and card.ability.extra.xmult > 1 then
@@ -439,32 +431,21 @@ SMODS.Joker {
 
   calculate = function (self, card, context)
     if context.selling_card and not context.blueprint then
-      card.ability.extra.Xmult = card.ability.extra.Xmult - card.ability.extra.Xmult_loss
-      if card.ability.extra.Xmult <= 1 then
-        G.E_MANAGER:add_event(Event({
-          func = function()
-              play_sound('tarot1')
-              card.T.r = -0.2
-              card:juice_up(0.3, 0.4)
-              card.states.drag.is = true
-              card.children.center.pinch.x = true
-              G.E_MANAGER:add_event(Event({trigger = 'after', delay = 0.3, blockable = false,
-                  func = function()
-                          G.jokers:remove_card(self)
-                          card:remove()
-                          card = nil
-                      return true; end})) 
-              return true
-          end
-        })) 
+      if card.ability.extra.Xmult - card.ability.extra.Xmult_loss <= 1 then
+        SMODS.destroy_cards(card, nil, nil, true)
         return {
           message = localize('pl_lasagna_mama_mia')
         }
       else
-        return {
-          message = localize{type='variable',key='a_xmult_minus',vars={card.ability.extra.Xmult_loss}},
-          colour = G.C.RED
-        }
+        SMODS.scale_card(card, {
+          ref_table = card.ability.extra,
+          ref_value = 'Xmult',
+          scalar_value = 'Xmult_loss',
+          operation = '-',
+          message_key = 'a_xmult_minus',
+          message_colour = G.C.MULT
+        })
+        return nil, true
       end
     end
 

--- a/src/additions/pl_jokers_w2.lua
+++ b/src/additions/pl_jokers_w2.lua
@@ -120,7 +120,7 @@ SMODS.Joker {
       return nil, true
     end
     
-    if context.end_of_round and not context.blueprint and not context.repetition and not context.individual and card.ability.extra.mult > 0 then
+    if context.end_of_round and not context.blueprint and context.main_eval and card.ability.extra.mult > 0 then
       SMODS.scale_card(card, {
         ref_table = card.ability.extra,
         ref_value = 'mult',
@@ -131,13 +131,10 @@ SMODS.Joker {
       return nil, true
     end
 
-    if context.joker_main and context.cardarea == G.jokers then
-      if card.ability.extra.mult > 0 then
-        return {
-          mult_mod = card.ability.extra.mult,
-          message = localize { type = 'variable', key = 'a_mult', vars = { card.ability.extra.mult } }
-        }
-      end
+    if context.joker_main then
+      return {
+        mult = card.ability.extra.mult
+      }
     end
   end
 }
@@ -185,13 +182,10 @@ SMODS.Joker {
       end
     end
 
-    if context.joker_main and context.cardarea == G.jokers then
-      if card.ability.extra.chips > 0 then
-        return {
-          chip_mod = card.ability.extra.chips,
-          message = localize { type = 'variable', key = 'a_chips', vars = { card.ability.extra.chips } }
-        }
-      end
+    if context.joker_main then
+      return {
+        chips = card.ability.extra.chips
+      }
     end
   end
 }
@@ -269,7 +263,7 @@ SMODS.Joker {
   end,
 
   calculate = function(self, card, context)
-    if context.before and context.cardarea == G.jokers then
+    if context.before then
       if (context.scoring_name == 'Three of a Kind') and not (card.ability.extra.last_hand == 'none') then
         return {
           message = localize('k_level_up_ex'),
@@ -278,7 +272,7 @@ SMODS.Joker {
         }
       end
     end
-    if context.cardarea == G.jokers and context.joker_main then
+    if context.joker_main then
       card.ability.extra.last_hand = context.scoring_name
     end
   end
@@ -310,11 +304,8 @@ SMODS.Joker {
         if SMODS.pseudorandom_probability(card, 'batteries', 1, card.ability.extra.chance) then 
           retriggers = 2
         end
-        return 
-        {
-          message = localize("k_again_ex"),
-          repetitions = retriggers,
-          card = card, 
+        return {
+          repetitions = retriggers
         }
       end
     end
@@ -341,12 +332,11 @@ SMODS.Joker {
   cost = 5,
 
   calculate = function(self, card, context)
-    if context.joker_main and context.cardarea == G.jokers then
+    if context.joker_main then
       if card.ability.extra.xmult > 1 then
         return 
           {
-            Xmult_mod = card.ability.extra.xmult,
-            message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.xmult } }
+            xmult = card.ability.extra.xmult
           }
       end
     end
@@ -397,10 +387,9 @@ SMODS.Joker {
     if context.destroying_card and SMODS.has_enhancement(context.destroying_card, 'm_stone') and not context.blueprint then
       return true
     end
-    if context.joker_main and context.cardarea == G.jokers and card.ability.extra.xmult > 1 then
+    if context.joker_main and card.ability.extra.xmult > 1 then
       return {
-        Xmult_mod = card.ability.extra.xmult,
-        message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.xmult } }
+        xmult = card.ability.extra.xmult
       }
     end
   end
@@ -449,10 +438,9 @@ SMODS.Joker {
       end
     end
 
-    if context.joker_main and context.cardarea == G.jokers then
+    if context.joker_main then
       return {
-        Xmult_mod = card.ability.extra.Xmult,
-        message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.Xmult } }
+        xmult = card.ability.extra.Xmult
       }
     end
   end

--- a/src/additions/pl_jokers_w2.lua
+++ b/src/additions/pl_jokers_w2.lua
@@ -9,6 +9,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.upgrades_left } }
   end,
+  attributes = {'retrigger', 'planet', 'food'},
 
   blueprint_compat = true,
   eternal_compat = false,
@@ -54,6 +55,7 @@ SMODS.Joker {
   end
 }
 
+SMODS.Attribute {key = 'booster'}
 SMODS.Joker {
   key = 'pop_up_joker',
   atlas = 'pl_atlas_w2',
@@ -64,6 +66,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { (G.GAME.probabilities.normal or 1), card.ability.extra.chance} }
   end,
+  attributes = {'chance', 'reroll', 'generation', 'booster', 'shop'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -111,6 +114,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.mult, card.ability.extra.mult_gain, card.ability.extra.mult_loss } }
   end,
+  attributes = {'mult', 'scaling', 'on_sell'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -153,6 +157,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.chips_mod, card.ability.extra.chips } }
   end,
+  attributes = {'chips', 'scaling', 'discard', 'hand_type'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -203,6 +208,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.money, card.ability.extra.money_mod, (G.GAME.probabilities.normal or 1), card.ability.extra.chance } }
   end,
+  attributes = {'economy', 'tarot', 'chance'},
 
   blueprint_compat = false,
   eternal_compat = false,
@@ -262,6 +268,7 @@ SMODS.Joker {
       return { vars = { localize('k_none') } }
     end
   end,
+  attributes = {'hand_type', 'hand_level'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -304,6 +311,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { (G.GAME.probabilities.normal or 1), card.ability.extra.chance } }
   end,
+  attributes = {'retrigger', 'chance', 'rank', 'ace'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -340,6 +348,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.xmult_mod, card.ability.extra.xmult } }
   end,
+  attributes = {'xmult', 'scaling', 'suit'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -378,6 +387,7 @@ SMODS.Joker {
     info_queue[#info_queue + 1] = G.P_CENTERS.m_stone
     return { vars = { card.ability.extra.xmult_mod, card.ability.extra.xmult } }
   end,
+  attributes = {'xmult', 'scaling', 'enhancements', 'destroy_card'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -413,6 +423,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return { vars = { card.ability.extra.Xmult, card.ability.extra.Xmult_loss } }
   end,
+  attributes = {'xmult', 'scaling', 'food'},
 
   blueprint_compat = true,
   eternal_compat = false,

--- a/src/additions/pl_jokers_w3.lua
+++ b/src/additions/pl_jokers_w3.lua
@@ -63,12 +63,11 @@ SMODS.Joker {
   calculate = function (self, card, context)
     if context.cardarea == G.hand and not context.end_of_round and context.individual and not context.repetition and context.other_card:is_suit(card.ability.extra.suit) then
       return {
-        chip_mod = card.ability.extra.chips,
+        chips = card.ability.extra.chips,
         card = context.other_card,
-        message = localize { type = 'variable', key = 'a_chips', vars = { card.ability.extra.chips } }
       }
     end
-    if context.end_of_round and not context.repetition and not context.individual then
+    if context.end_of_round and context.main_eval then
       local suits = {'Diamonds', 'Clubs', 'Hearts', 'Spades'}
       for k, v in ipairs(suits) do
         if v == card.ability.extra.suit then

--- a/src/additions/pl_jokers_w3.lua
+++ b/src/additions/pl_jokers_w3.lua
@@ -12,6 +12,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     info_queue[#info_queue + 1] = G.P_CENTERS.c_wheel_of_fortune
   end,
+  attributes = {'generation', 'tarot'},
 
   rarity = 1,
   cost = 3,
@@ -47,6 +48,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return {vars = { localize(card.ability.extra.suit, 'suits_singular'), card.ability.extra.chips, colours = {G.C.SUITS[card.ability.extra.suit]}}}
   end,
+  attributes = {'chips', 'suit'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -95,6 +97,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return {vars = { card.ability.extra.xmult }}
   end,
+  attributes = {'xmult', 'rank', 'two', 'four', 'eight'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -142,6 +145,7 @@ SMODS.Joker {
   loc_vars = function(self, info_queue, card)
     return {vars = { card.ability.extra.mult }}
   end,
+  attributes = {'mult', 'rank'},
 
   blueprint_compat = true,
   eternal_compat = true,
@@ -181,6 +185,7 @@ SMODS.Joker {
       return { vars = { localize('k_none') } }
     end
   end,
+  attributes = {'destroy_card', 'hand_level'},
 
   blueprint_compat = true,
   eternal_compat = true,

--- a/src/additions/pl_jokers_w3.lua
+++ b/src/additions/pl_jokers_w3.lua
@@ -20,16 +20,12 @@ SMODS.Joker {
   calculate = function (self, card, context)
     if context.setting_blind and not (context.blueprint_card or self).getting_sliced and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
       G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
-        G.E_MANAGER:add_event(Event({
-          trigger = 'before',
-          delay = 0.0,
-          func = (function()
-                  local card = create_card('Tarot',G.consumeables, nil, nil, nil, nil, 'c_wheel_of_fortune')
-                  card:add_to_deck()
-                  G.consumeables:emplace(card)
-                  G.GAME.consumeable_buffer = 0
-              return true
-          end)}))
+      G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
+      G.E_MANAGER:add_event(Event({func = function()
+        SMODS.add_card{set = 'Tarot', area = G.consumeables, key = 'c_wheel_of_fortune'}
+        G.GAME.consumeable_buffer = 0
+        return true
+      end}))
       return {
           message = localize('k_plus_tarot'),
           colour = G.C.SECONDARY_SET.Tarot,
@@ -196,18 +192,18 @@ SMODS.Joker {
   cost = 8,
 
   calculate = function (self, card, context)
-    if context.cardarea == G.jokers and context.joker_main then
-      self.pl_check_most_played(card)
-    end
     if context.setting_blind then
+      self.pl_check_most_played(card)
       for i=1, #G.consumeables.cards do
         SMODS.destroy_cards(G.consumeables.cards[i])
       end
       if card.ability.extra.most_played_hand then
         card_eval_status_text(context.blueprint_card or card, 'extra', nil, nil, nil, {message = localize('k_upgrade_ex')})
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 0.8, delay = 0.3}, {handname=localize(card.ability.extra.most_played_hand, 'poker_hands'),chips = G.GAME.hands[card.ability.extra.most_played_hand].chips, mult = G.GAME.hands[card.ability.extra.most_played_hand].mult, level=G.GAME.hands[card.ability.extra.most_played_hand].level})
-        level_up_hand(context.blueprint_card or card, card.ability.extra.most_played_hand, nil, 1)
-        update_hand_text({sound = 'button', volume = 0.7, pitch = 1.1, delay = 0}, {mult = 0, chips = 0, handname = '', level = ''})
+        SMODS.upgrade_poker_hands{
+          hands = {card.ability.extra.most_played_hand},
+          from = card
+        }
+        return nil, true
       end
     end
   end,

--- a/src/utilities/functions.lua
+++ b/src/utilities/functions.lua
@@ -2,7 +2,7 @@ function PL_UTIL.wild_card_count()
   local count = 0
   if G.playing_cards then
     for k, v in pairs(G.playing_cards) do
-      if v.config.center == G.P_CENTERS.m_wild then count = count + 1 end
+      if SMODS.has_enhancement(v, 'm_wild') then count = count + 1 end
     end
   end
   return count


### PR DESCRIPTION
- add [attributes](https://github.com/Steamodded/smods/wiki/SMODS.Attributes) to every joker
- implement `SMODS.scale_card` for Mini Crossword, Apple Pie, Black Cat, Lamp, Odd Sock, Hot Air Balloon, Painterly Joker, Quarry, and Lasagna
- implement SMODS probability functions for Plantain, Pop-Up Joker, Hot Air Balloon, and Loose Batteries
- implement `SMODS.destroy_card` for Plantain, Apple Pie, Grape Soda, Croissant, Hot Air Balloon
- implement `SMODS.add_card` for Crystal Joker and Early Man
- implement `SMODS.has_enhancement` for Crystal Joker, El Dorado, and Quarry
- use `level_up` effect for Three Body Problem, and `SMODS.upgrade_poker_hands` for Extraterrestrial Joker (also, fixed a minor bug with Extraterrestrial Joker where it wouldn't know the most played hand sometimes)
- use `context.selling_card` for Lamp (and remove patch that added its own context)
- use `context.change_suit` for Painterly Joker (and remove patch that added its own context)
- use `SMODS.find_card` for Grape Soda functions
- use `SMODS.calculate_context` for adding the cash-out context
- remove unnecessary `context.cardarea` checks during joker scoring
- use `context.main_eval` where relevant for end of round effects
- simplify scoring returns
- adjust postcard logic to more accurately match its description